### PR TITLE
Feat/#19 padmin role change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
+  // <React.StrictMode>
     <App />
-  </React.StrictMode>
+  // </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/page/member/KakaoCallback.js
+++ b/src/page/member/KakaoCallback.js
@@ -5,7 +5,7 @@ import Snackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
-import {useAuth} from "../../context/AuthContext";
+import { useAuth } from "../../context/AuthContext";
 
 const Alert = React.forwardRef(function Alert(props, ref) {
     return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
@@ -14,11 +14,12 @@ const Alert = React.forwardRef(function Alert(props, ref) {
 const KakaoCallback = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const {login} = useAuth();
+    const { login } = useAuth();
 
     const [openSnackbar, setOpenSnackbar] = useState(false);
     const [snackbarMessage, setSnackbarMessage] = useState('');
     const [snackbarSeverity, setSnackbarSeverity] = useState('error');
+    const [isRequestSent, setIsRequestSent] = useState(false);  // 중복 요청 방지 상태
 
     const handleSnackbarClose = () => {
         setOpenSnackbar(false);
@@ -28,9 +29,11 @@ const KakaoCallback = () => {
         const searchParams = new URLSearchParams(location.search);
         const code = searchParams.get('code');
 
-        if (code) {
+        // 요청을 한 번도 보내지 않았고, code가 있을 경우에만 요청
+        if (code && !isRequestSent) {
             const fetchTokens = async () => {
                 try {
+                    setIsRequestSent(true);  // 첫 번째 요청 이후 요청 방지 플래그 설정
                     const response = await axios.post(`http://localhost:8080/api/v1/members/oauth/KAKAO`, {
                         code: code,
                         state: ""
@@ -38,11 +41,9 @@ const KakaoCallback = () => {
 
                     // 응답에서 리디렉션 여부를 확인
                     if (response.data === 'redirect nicknamePage') {
-                        // 닉네임 설정 화면으로 리디렉션
                         navigate('/nickname', { replace: true });
                     } else {
-                        // 정상적으로 토큰을 받은 경우
-                        const { accessToken, refreshToken, userName } = response.data;
+                        const { accessToken, refreshToken, userName, firstLogin } = response.data;
 
                         localStorage.setItem('access_token', accessToken);
                         localStorage.setItem('refresh_token', refreshToken);
@@ -54,13 +55,23 @@ const KakaoCallback = () => {
                         setSnackbarMessage('로그인에 성공했습니다.');
                         setOpenSnackbar(true);
 
-                        setTimeout(() => {
-                            navigate('/', { replace: true });
-                        }, 1000);
-                    }
+                        if (firstLogin === true) {
+                            await axios.patch(`http://localhost:8080/api/v1/members/first-login`);
 
+                            setTimeout(() => {
+                                navigate('/member/category', { state: { from: '/signin' } });
+
+                            }, 1000);
+                        }
+
+
+                        else{
+                            setTimeout(() => {
+                                navigate('/', { replace: true });
+                            }, 1000);
+                        }
+                    }
                 } catch (error) {
-                    // 에러 상태 코드에 따른 메시지 처리
                     if (error.response && error.response.status === 409) {
                         setSnackbarSeverity('error');
                         setSnackbarMessage('이미 사용중인 이메일입니다. 다른 소셜 이메일로 회원가입 시도해주세요');
@@ -79,8 +90,7 @@ const KakaoCallback = () => {
 
             fetchTokens();
         }
-    }, [location.search, navigate]);
-
+    }, [location.search, navigate, isRequestSent]);
 
     return (
         <div>

--- a/src/page/member/KakaoCallback.js
+++ b/src/page/member/KakaoCallback.js
@@ -48,7 +48,6 @@ const KakaoCallback = () => {
                         localStorage.setItem('refresh_token', refreshToken);
                         localStorage.setItem('user_name', userName);
 
-
                         login(userName);
 
                         setSnackbarSeverity('success');
@@ -61,20 +60,27 @@ const KakaoCallback = () => {
                     }
 
                 } catch (error) {
-                    console.error('카카오 로그인 중 오류가 발생했습니다:', error);
-                    setSnackbarSeverity('error');
-                    setSnackbarMessage('카카오 로그인 중 오류가 발생했습니다.');
+                    // 에러 상태 코드에 따른 메시지 처리
+                    if (error.response && error.response.status === 409) {
+                        setSnackbarSeverity('error');
+                        setSnackbarMessage('이미 사용중인 이메일입니다. 다른 소셜 이메일로 회원가입 시도해주세요');
+                    } else {
+                        setSnackbarSeverity('error');
+                        setSnackbarMessage('카카오 로그인 중 오류가 발생했습니다.');
+                    }
+
                     setOpenSnackbar(true);
 
                     setTimeout(() => {
                         navigate('/signin');
-                    }, 1000);
+                    }, 2000);
                 }
             };
 
             fetchTokens();
         }
     }, [location.search, navigate]);
+
 
     return (
         <div>

--- a/src/page/member/MemberCategoryPage.js
+++ b/src/page/member/MemberCategoryPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect} from 'react';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
@@ -6,7 +6,7 @@ import Container from '@mui/material/Container';
 import axios from '../../api/axiosInterceptor';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import SomunIcon from '../../assets/image/somun_icon.png';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate,useLocation } from 'react-router-dom';
 import Snackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
 import CssBaseline from '@mui/material/CssBaseline';  // CssBaseline 추가
@@ -39,6 +39,7 @@ export default function MemberCategoryPage() {
     const [snackbarSeverity, setSnackbarSeverity] = useState('success'); // Snackbar 종류
 
     const navigate = useNavigate();
+    const location = useLocation();
 
     // 카테고리 전체 목록 및 사용자 선호 카테고리 불러오기
     useEffect(() => {
@@ -108,9 +109,14 @@ export default function MemberCategoryPage() {
             setSnackbarSeverity('success');
             setOpenSnackbar(true);
 
-            // 1초 후 로그인 페이지로 이동
             setTimeout(() => {
-                navigate('/member/profile');
+                // 이전 페이지가 로그인 페이지인지 확인하거나 명시적으로 홈으로 리다이렉트
+                const previousPage = location.state?.from;
+                if (previousPage && previousPage === '/signin') {
+                    navigate('/'); // 로그인 페이지가 이전 페이지면 홈으로 이동
+                } else {
+                    navigate(-1);  // 그렇지 않으면 이전 페이지로 이동
+                }
             }, 1000);
         } catch (error) {
             console.error('카테고리를 제출하는 중 오류가 발생했습니다:', error);

--- a/src/page/member/NaverCallBack.js
+++ b/src/page/member/NaverCallBack.js
@@ -5,7 +5,7 @@ import Snackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
-import {useAuth} from "../../context/AuthContext";
+import { useAuth } from "../../context/AuthContext";
 
 const Alert = React.forwardRef(function Alert(props, ref) {
     return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
@@ -14,11 +14,12 @@ const Alert = React.forwardRef(function Alert(props, ref) {
 const NaverCallback = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const {login} = useAuth();
+    const { login } = useAuth();
 
     const [openSnackbar, setOpenSnackbar] = useState(false);
     const [snackbarMessage, setSnackbarMessage] = useState('');
     const [snackbarSeverity, setSnackbarSeverity] = useState('error');
+    const [isRequestSent, setIsRequestSent] = useState(false);  // 중복 요청 방지 상태
 
     const handleSnackbarClose = () => {
         setOpenSnackbar(false);
@@ -30,9 +31,11 @@ const NaverCallback = () => {
         const code = searchParams.get('code');
         const state = searchParams.get('state');
 
-        if (code && state) {
+        // 요청을 한 번도 보내지 않았고, code와 state가 있을 경우에만 요청
+        if (code && state && !isRequestSent) {
             const fetchTokens = async () => {
                 try {
+                    setIsRequestSent(true);  // 첫 번째 요청 이후 요청 방지 플래그 설정
                     const response = await axios.post(`http://localhost:8080/api/v1/members/oauth/NAVER`, {
                         code: code,
                         state: state
@@ -40,11 +43,9 @@ const NaverCallback = () => {
 
                     // 응답에서 리디렉션 여부를 확인
                     if (response.data === 'redirect nicknamePage') {
-                        // 닉네임 설정 화면으로 리디렉션
                         navigate('/nickname', { replace: true });
                     } else {
-                        // 정상적으로 토큰을 받은 경우
-                        const { accessToken, refreshToken, userName } = response.data;
+                        const { accessToken, refreshToken, userName, firstLogin } = response.data;
 
                         localStorage.setItem('access_token', accessToken);
                         localStorage.setItem('refresh_token', refreshToken);
@@ -56,15 +57,22 @@ const NaverCallback = () => {
                         setSnackbarMessage('로그인에 성공했습니다.');
                         setOpenSnackbar(true);
 
-                        // 홈 화면으로 리디렉트
-                        setTimeout(() => {
-                            navigate('/', { replace: true });
-                        }, 1000);
+                        if (firstLogin === true) {
+                            await axios.patch(`http://localhost:8080/api/v1/members/first-login`);
+
+                            setTimeout(() => {
+                                navigate('/member/category', { state: { from: '/signin' } });
+                            }, 1000);
+                        }
+
+                        else{
+                            // 홈 화면으로 리디렉트
+                            setTimeout(() => {
+                                navigate('/', { replace: true });
+                            }, 1000);
+                        }
                     }
-
-
                 } catch (error) {
-                    // 에러 상태 코드에 따른 메시지 처리
                     if (error.response && error.response.status === 409) {
                         setSnackbarSeverity('error');
                         setSnackbarMessage('이미 사용중인 이메일입니다. 다른 소셜 이메일로 회원가입 시도해주세요');
@@ -83,7 +91,7 @@ const NaverCallback = () => {
 
             fetchTokens();
         }
-    }, [location.search, navigate]);
+    }, [location.search, navigate, isRequestSent]);
 
     return (
         <div>

--- a/src/page/member/NaverCallBack.js
+++ b/src/page/member/NaverCallBack.js
@@ -64,14 +64,20 @@ const NaverCallback = () => {
 
 
                 } catch (error) {
-                    console.error('네이버 로그인 중 오류가 발생했습니다:', error);
-                    setSnackbarSeverity('error');
-                    setSnackbarMessage('네이버 로그인 중 오류가 발생했습니다.');
+                    // 에러 상태 코드에 따른 메시지 처리
+                    if (error.response && error.response.status === 409) {
+                        setSnackbarSeverity('error');
+                        setSnackbarMessage('이미 사용중인 이메일입니다. 다른 소셜 이메일로 회원가입 시도해주세요');
+                    } else {
+                        setSnackbarSeverity('error');
+                        setSnackbarMessage('네이버 로그인 중 오류가 발생했습니다.');
+                    }
+
                     setOpenSnackbar(true);
 
                     setTimeout(() => {
                         navigate('/signin');
-                    }, 1000);
+                    }, 2000);
                 }
             };
 

--- a/src/page/member/SigninPage.js
+++ b/src/page/member/SigninPage.js
@@ -96,7 +96,7 @@ export default function SignIn() {
             const response = await axios.post('http://localhost:8080/api/v1/members/authenticate', loginData);
 
             // 응답 데이터에서 액세스 토큰과 리프레시 토큰을 가져옴
-            const { accessToken, refreshToken,userName } = response.data;
+            const { accessToken, refreshToken,userName, firstLogin } = response.data;
 
             // 토큰을 localStorage에 저장
             await localStorage.setItem('access_token', accessToken);
@@ -111,10 +111,20 @@ export default function SignIn() {
             setSnackbarMessage("로그인에 성공했습니다.");
             setOpenSnackbar(true);
 
-            // 로그인 후 리다이렉트 (예: 홈으로 이동)
-            setTimeout(() => {
-                navigate('/');
-            }, 1000);
+            if (firstLogin === true) {
+                await axios.patch(`http://localhost:8080/api/v1/members/first-login`);
+
+                setTimeout(() => {
+                    navigate('/member/category', { replace: true });
+                }, 1000);
+            }
+
+            else{
+                // 로그인 후 리다이렉트 (예: 홈으로 이동)
+                setTimeout(() => {
+                    navigate('/');
+                }, 1000);
+            }
 
         } catch (error) {
             setSnackbarSeverity('error');


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
* 소설 서비스로 회원가입시 만약 해당 이메일이 이미 사용중이라면 그에맞는 alert가 응답되도록 수정하였습니다.
* 첫 로그인시에만 선호카테고리를 정하는 페이지로 리다이렉트되고, 다음 로그인부터는 바로 홈화면으로 리다이렉트 되도록 하였습니다.


## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
index.js에서 StrictMode가 활성화되어있으면 검증을 위해 useEffect() 가 2번 실행되어 소셜 로그인에서 선호카테고리로 넘어가는 로직이 정상적으로 동작하지않아서 주석처리했습니다! 혹시라도 StrictMode가 필요하시다면 주석을 해제하고 실행해주시면 될 것같습니다!
